### PR TITLE
Update CalculateAction.cs

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/CalculateAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/CalculateAction.cs
@@ -30,12 +30,19 @@ namespace ActionsList
             if (Combat.AttackStep == CombatStep.Defence)
             {
                 int attackSuccessesCancelable = Combat.DiceRollAttack.SuccessesCancelable;
-                int defenceSuccesses = Combat.DiceRollDefence.Successes;
+                int defenceSuccesses = Combat.CurrentDiceRoll.Successes;
                 if (attackSuccessesCancelable > defenceSuccesses)
                 {
-                    int defenceFocuses = Combat.DiceRollDefence.Focuses;
-                    if (defenceFocuses > 0)
+                    int defenceFocuses = Combat.CurrentDiceRoll.Focuses;
+                    int numFocusTokens = Selection.ActiveShip.Tokens.CountTokensByType(typeof(FocusToken));
+                    if (numFocusTokens > 0 && defenceFocuses > 1)
                     {
+                        // Multiple focus results on our defense roll and we have a Focus token.  Use it instead of the Calculate.
+                        result = 0;
+                    }
+                    else if (defenceFocuses > 0)
+                    {
+                        // We don't have a focus token.  Better use the Calculate. 
                         result = 41;
                     }
                 }
@@ -43,7 +50,7 @@ namespace ActionsList
 
             if (Combat.AttackStep == CombatStep.Attack)
             {
-                int attackFocuses = Combat.DiceRollAttack.Focuses;
+                int attackFocuses = Combat.CurrentDiceRoll.Focuses;
                 if (attackFocuses > 0)
                 {
                     result = 41;


### PR DESCRIPTION
AI will now use Calculate tokens only if it doesn't have a Focus token that would work better.  Ships similar to Guri, General Grievous with Kraken, and a ship with 0-0-0 will get better use from their tokens.