### PR TITLE
Update VultureClassDroidFighter.cs

### DIFF
--- a/Assets/Scripts/Model/Content/SecondEdition/Ships/VultureClassDroidFighter.cs
+++ b/Assets/Scripts/Model/Content/SecondEdition/Ships/VultureClassDroidFighter.cs
@@ -8,6 +8,7 @@ using Arcs;
 using Movement;
 using Ship;
 using SubPhases;
+using Tokens;
 using Upgrade;
 
 namespace Ship.SecondEdition.VultureClassDroidFighter
@@ -135,7 +136,40 @@ namespace Abilities.SecondEdition
         
         private int GetDiceModificationAiPriority()
         {
-            return 40;
+            int result = 0;
+
+            if (Combat.AttackStep == CombatStep.Defence)
+            {
+                int attackSuccessesCancelable = Combat.DiceRollAttack.SuccessesCancelable;
+                int defenceSuccesses = Combat.CurrentDiceRoll.Successes;
+                if (attackSuccessesCancelable > defenceSuccesses)
+                {
+                    int defenceFocuses = Combat.CurrentDiceRoll.Focuses;
+                    int numFocusTokens = Selection.ActiveShip.Tokens.CountTokensByType(typeof(FocusToken));
+                    if (numFocusTokens > 0 && defenceFocuses > 1)
+                    {
+                        // Multiple focus results on our defense roll and we have a Focus token.  Use it instead of the Calculate.
+                        result = 0;
+                    }
+                    else if (defenceFocuses > 0)
+                    {
+                        // We don't have a focus token.  Better use the Calculate.
+                        result = 41;
+                    }
+                }
+
+            }
+
+            if (Combat.AttackStep == CombatStep.Attack)
+            {
+                int attackFocuses = Combat.CurrentDiceRoll.Focuses;
+                if (attackFocuses > 0)
+                {
+                    result = 41;
+                }
+            }
+
+            return result;
         }
 
         private void PayAbilityCost(Action<bool> callback)


### PR DESCRIPTION
Vulture droids will no longer waste Network Calculation tokens on rolls that can't use them.