### PR TITLE
Update TargetLockAction.cs

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/TargetLockAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/TargetLockAction.cs
@@ -8,7 +8,9 @@ using SubPhases;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using Tokens;
 using UnityEngine;
+using Upgrade;
 
 namespace ActionsList
 {
@@ -70,16 +72,18 @@ namespace ActionsList
 
             if (Combat.AttackStep == CombatStep.Attack)
             {
-                int attackFocuses = Combat.DiceRollAttack.FocusesNotRerolled;
-                int attackBlanks = Combat.DiceRollAttack.BlanksNotRerolled;
+                int attackFocuses = Combat.CurrentDiceRoll.FocusesNotRerolled;
+                int attackBlanks = Combat.CurrentDiceRoll.BlanksNotRerolled;
+                int numFocusTokens = Selection.ActiveShip.Tokens.CountTokensByType(typeof(FocusToken));
 
-                //if (Combat.Attacker.HasToken(typeof(Tokens.FocusToken)))
-                if (Combat.Attacker.GetDiceModificationsGenerated().Count(n => n.IsTurnsAllFocusIntoSuccess) > 0)
+                if (numFocusTokens > 0)
                 {
+                    // Focus tokens can take care of our Focus results.  Use the Target Lock if there are any blanks.
                     if (attackBlanks > 0) result = 80;
                 }
                 else
                 {
+                    // We don't have any focus tokens.  If we have 1 or more blank + Focus results, use our Target Lock.
                     if (attackBlanks + attackFocuses > 0) result = 80;
                 }
             }
@@ -108,6 +112,107 @@ namespace ActionsList
             {
                 Phases.GoBack();
             }
+        }
+
+        public override int GetActionPriority()
+        {
+            int result = 0;
+
+            result = 0;
+
+            int maxOrdinanceRange = -1;
+            int minOrdinanceRange = 99;
+            int minShipTargetRange = 1;
+            int curOrdinanceMax = -1;
+            int curOrdinanceMin = -1;
+            int numTargetLockTargets = 0;
+            bool validTargetLockedAlready = false;
+            if (Selection.ThisShip.ShipInfo.ShipName == "E-wing")
+            {
+                minShipTargetRange = 2;
+            }
+
+            // Find the combined maximum and minimum range of all of our ordinance that currently has charges.
+            foreach (GenericUpgrade currentUpgrade in Selection.ThisShip.UpgradeBar.GetUpgradesOnlyFaceup())
+            {
+                if (currentUpgrade.HasType(UpgradeType.Missile) || currentUpgrade.HasType(UpgradeType.Torpedo) && currentUpgrade.State.Charges > 0)
+                {
+                    if (currentUpgrade.UpgradeInfo.WeaponInfo.RequiresToken == typeof(BlueTargetLockToken))
+                    {
+                        curOrdinanceMax = currentUpgrade.UpgradeInfo.WeaponInfo.MaxRange;
+                        curOrdinanceMin = currentUpgrade.UpgradeInfo.WeaponInfo.MinRange;
+
+                        if (curOrdinanceMin < minOrdinanceRange && curOrdinanceMin >= minShipTargetRange)
+                        {
+                            minOrdinanceRange = curOrdinanceMin;
+                        }
+                        if (curOrdinanceMax > maxOrdinanceRange)
+                        {
+                            maxOrdinanceRange = curOrdinanceMax;
+                        }
+                    }
+                }
+            }
+            // If our minimum range is less than 99, we have ordinance that is loaded and have set our min and max ranges.
+            // Check all enemy ships to see if they are in range of our ordinance.
+            if (minOrdinanceRange < 99)
+            {
+                foreach (var anotherShip in Roster.GetPlayer(Roster.AnotherPlayer(Selection.ThisShip.Owner.PlayerNo)).Ships)
+                {
+                    ShotInfo shotInfo = new ShotInfo(Selection.ThisShip, anotherShip.Value, Selection.ThisShip.PrimaryWeapons);
+                    if ((shotInfo.Range <= maxOrdinanceRange) && (shotInfo.Range >= minOrdinanceRange) && (shotInfo.IsShotAvailable))
+                    {
+                        if (!ActionsHolder.HasTargetLockOn(Selection.ThisShip, anotherShip.Value))
+                        {
+                            // We have a target in range that doesn't have a target lock on it from us.
+                            numTargetLockTargets++;
+                        }
+                        else
+                        {
+                            // We already have a target in range that has our target lock on it.
+                            validTargetLockedAlready = true;
+                        }
+                    }
+                }
+                if (validTargetLockedAlready == false && numTargetLockTargets > 0)
+                {
+                    // We have ordinance, we have targets for that ordinance, and none of them have our target lock on them.
+                    result += 55;
+                }
+            }
+
+
+            if (Selection.ThisShip.State.Force > 1 && result == 0)
+            {
+                // We have at least 2 Force and we haven't already decided to possibly perform a target lock action.
+                validTargetLockedAlready = false;
+                numTargetLockTargets = 0;
+                // Jedi with 2 or more Force should target lock more often than they focus.
+                foreach (var anotherShip in Roster.GetPlayer(Roster.AnotherPlayer(Selection.ThisShip.Owner.PlayerNo)).Ships)
+                {
+                    ShotInfo shotInfo = new ShotInfo(Selection.ThisShip, anotherShip.Value, Selection.ThisShip.PrimaryWeapons);
+                    if ((shotInfo.Range < 4) && (shotInfo.IsShotAvailable))
+                    {
+                        if (!ActionsHolder.HasTargetLockOn(Selection.ThisShip, anotherShip.Value))
+                        {
+                            // We have a target in range that doesn't have a target lock on it from us.
+                            numTargetLockTargets++;
+                        }
+                        else
+                        {
+                            // We already have a target in range that has our target lock on it.
+                            validTargetLockedAlready = true;
+                        }
+                    }
+                }
+                if (validTargetLockedAlready == false && numTargetLockTargets > 0)
+                {
+                    // We don't already have a target that is in range and locked, and we have targets available.
+                    result += 15;
+                }
+            }
+
+            return result;
         }
     }
 
@@ -161,7 +266,9 @@ namespace SubPhases
 
         private bool FilterTargetLockTargets(GenericShip ship)
         {
-            return ship.Owner.PlayerNo != Selection.ThisShip.Owner.PlayerNo && Rules.TargetLocks.TargetLockIsAllowed(Selection.ThisShip, ship);
+            // Don't include targets that are owned by the target locking player, ships that can't get target locks, or ships that already have a target lock from this ship.
+            // Without the last test, Redline can target lock the same target twice.
+            return (ship.Owner.PlayerNo != Selection.ThisShip.Owner.PlayerNo && Rules.TargetLocks.TargetLockIsAllowed(Selection.ThisShip, ship) && !ActionsHolder.HasTargetLockOn(Selection.ThisShip, ship));
         }
 
         private int GetTargetLockAiPriority(GenericShip ship)


### PR DESCRIPTION
AI will now use the Target Lock Action if they have munitions with charges available, or if they have 2 or more Force tokens.

AI will spend target lock tokens on targets when their attack dice can't be resolved otherwise.