### PR TITLE
Update ReloadAction.cs

### DIFF
--- a/Assets/Scripts/Model/Actions/ActionsList/ReloadAction.cs
+++ b/Assets/Scripts/Model/Actions/ActionsList/ReloadAction.cs
@@ -45,8 +45,24 @@ namespace ActionsList
         {
             int result = 0;
 
-            int discardedOrdnance = Selection.ThisShip.UpgradeBar.GetUpgradesOnlyDiscarded().Count(n => n.HasType(UpgradeType.Missile) || n.HasType(UpgradeType.Torpedo));
-            result = discardedOrdnance * 30;
+            if (Edition.Current.Name == "First Edition")
+            {
+                // Ordinance is discarded when used in First Edition.
+                int discardedOrdnance = Selection.ThisShip.UpgradeBar.GetUpgradesOnlyDiscarded().Count(n => n.HasType(UpgradeType.Missile) || n.HasType(UpgradeType.Torpedo));
+                result = discardedOrdnance * 30;
+            }
+            else
+            {
+                foreach (GenericUpgrade currentUpgrade in Selection.ThisShip.UpgradeBar.GetUpgradesOnlyFaceup())
+                {
+                    // Only perform a reload if the upgradeable ordinance has less than their maximum charges.
+                    if ((currentUpgrade.HasType(UpgradeType.Missile) || currentUpgrade.HasType(UpgradeType.Torpedo) || currentUpgrade.HasType(UpgradeType.Bomb)) && currentUpgrade.State.Charges < currentUpgrade.State.MaxCharges)
+                    {
+                        // Consider reloading if we have any munitions that need it.  Increase the odds of reloading if more than one munitions card needs reloaded, as it means this ship relies heavily on munitions.
+                        result += 30;
+                    }
+                }
+            }
 
             return result;
         }


### PR DESCRIPTION
AI will now put a low priority on reloading munitions that are lower than maximum charge.  If the ship has multiple munition sources, the priority increases for each additional source.